### PR TITLE
Make ZIP package non-safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,5 @@ setup(
     install_requires=[],
     packages=find_packages(),
     include_package_data=True,
+    zip_safe=False,
 )


### PR DESCRIPTION
This change is required as of NetBox 2.10.2 to avoid installation failure.
It should be backward compatible with older NetBox versions as there are no changes to the code itself.

See: netbox-community/netbox/issues/5254