### PR TITLE
Add SAML2CustomAttrUserBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ variables defined in the configuration.py file, as described here:
 https://netbox.readthedocs.io/en/stable/configuration/optional-settings/
 
 This repository provides a Netbox plugin that can be used to integrate with a SAML SSO system,
-such as Okta.  
+such as Okta.
 
 *NOTE: This approach uses a reverse-proxy URL rewrite so that the standard Netbox Login will redirect
 the User to the SSO system.  Please refer to the example [nginx.conf](nginx.conf) file.*
@@ -56,6 +56,34 @@ PLUGINS_CONFIG = {
         'METADATA_AUTO_CONF_URL': "https://mycorp.okta.com/app/sadjfalkdsflkads/sso/saml/metadata",
         # or local file path
         'METADATA_LOCAL_FILE_PATH': '/opt/netbox/saml2.xml',
+
+        # Settings for SAML2CustomAttrUserBackend. Optional.
+        'CUSTOM_ATTR_BACKEND': {
+            # Attribute containing the username. Optional.
+            'USERNAME_ATTR': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+            # Attribute containing the user's email. Optional.
+            'MAIL_ATTR': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+            # Attribute containing the user's first name. Optional.
+            'FIRST_NAME_ATTR': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname',
+            # Attribute containing the user's last name. Optional.
+            'LAST_NAME_ATTR': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname',
+            # Set to True to always update the user on logon
+            # from SAML attributes on logon. Defaults to False.
+            'ALWAYS_UPDATE_USER': False,
+            # Attribute that contains groups. Optional.
+            'GROUP_ATTR': 'http://schemas.microsoft.com/ws/2008/06/identity/claims/groups',
+            # Dict of user flags to groups.
+            # If the user is in the group then the flag will be set to True. Optional.
+            'FLAGS_BY_GROUP': {
+                'is_staff': 'saml-group1',
+                'is_superuser': 'saml-group2'
+            },
+            # Dict of SAML groups to NetBox groups. Optional.
+            # Groups must be created beforehand in NetBox.
+            'GROUP_MAPPINGS': {
+                'saml-group3': 'netbox-group'
+            }
+        }
     }
 }
 ```
@@ -72,7 +100,7 @@ to be used in the reverse-proxy redirect, for examlple see [nginx.conf](nginx.co
 <br/><br/>
 `/sso/acs/`<br/>
 This URLs should be configured into your SSO system as the route to use to single-sign-on/redirection URL the User into Netbox
-after the User has authenticated with the SSO system. 
+after the User has authenticated with the SSO system.
 
 # Customizing on Create New User Configuration
 If you want to customize the way a User is created, beyond what is provided by the

--- a/django3_saml2_nbplugin/backends.py
+++ b/django3_saml2_nbplugin/backends.py
@@ -1,5 +1,7 @@
-from django.contrib.auth.models import User
+from typing import Optional
+from django.contrib.auth.models import User, Group
 from django.core.handlers.wsgi import WSGIRequest
+from django.conf import settings
 from saml2.response import AuthnResponse
 
 # Subclass from the Netbox provided RemoteUserBackend so that we get the
@@ -41,6 +43,7 @@ class SAML2AttrUserBackend(RemoteUserBackend):
 
     The User name will be set to <first_name>.<last_name> in lower-case.
     """
+
     def authenticate(self, request: WSGIRequest, remote_user: str) -> User:
         """
         This method must use the SAML2 attributes to formulate the User name
@@ -83,6 +86,92 @@ class SAML2AttrUserBackend(RemoteUserBackend):
             missing_attr = exc.args[0]
             be_name = self.__class__.__name__
             raise PermissionError(f"SAML2 backend {be_name} missing attribute: {missing_attr}")
+
+        # call Netbox superclass for further processing of REMOTE_AUTH_xxx variables.
+        return super().configure_user(request, user)
+
+
+class SAML2CustomAttrUserBackend(RemoteUserBackend):
+    """
+    This backend will configure the following attributes from SAML attributes:
+        * first_name
+        * last_name
+        * email
+        * any flags
+    """
+
+    def authenticate(self, request: WSGIRequest, remote_user: str) -> Optional[User]:
+        """
+        This method uses a user defined attribute for the username or Name ID if
+        USERNAME_ATTR is not configured.
+        """
+        be_settings = settings.PLUGINS_CONFIG["django3_saml2_nbplugin"].get("CUSTOM_ATTR_BACKEND", {})
+
+        saml2_auth_resp: AuthnResponse = request.META['SAML2_AUTH_RESPONSE']
+        user_ident = saml2_auth_resp.get_identity()
+
+        try:
+            if "USERNAME_ATTR" in be_settings:
+                remote_user = user_ident[be_settings["USERNAME_ATTR"]][0]
+
+        except KeyError as exc:
+            missing_attr = exc.args[0]
+            be_name = self.__class__.__name__
+            raise PermissionError(f"SAML2 backend {be_name} missing attribute: {missing_attr}")
+
+        if be_settings.get("ALWAYS_UPDATE_USER", False):
+            user = super().authenticate(request, remote_user)
+            # The RemoteUserBackend may return None on auth failure
+            if user is None:
+                return None
+            return self.configure_user(request, user)
+        else:
+            return super().authenticate(request, remote_user)
+
+    def configure_user(self, request: WSGIRequest, user: User) -> User:
+        """
+        This method will always be called on login when ALWAYS_UPDATE_USER is True.
+        This method will uses SAML attributes to configure the following:
+           * first_name
+           * last_name
+           * email
+           * user flags
+           * groups
+        """
+        be_settings = settings.PLUGINS_CONFIG["django3_saml2_nbplugin"].get("CUSTOM_ATTR_BACKEND", {})
+
+        saml2_auth_resp: AuthnResponse = request.META['SAML2_AUTH_RESPONSE']
+        user_ident = saml2_auth_resp.get_identity()
+
+        try:
+            if "FIRST_NAME_ATTR" in be_settings:
+                user.first_name = user_ident[be_settings["FIRST_NAME_ATTR"]][0]
+            if "LAST_NAME_ATTR" in be_settings:
+                user.last_name = user_ident[be_settings["LAST_NAME_ATTR"]][0]
+            if "MAIL_ATTR" in be_settings:
+                user.email = user_ident[be_settings["MAIL_ATTR"]][0]
+            if "GROUP_ATTR" in be_settings:
+                ident_groups = user_ident[be_settings["GROUP_ATTR"]]
+            else:
+                ident_groups = []
+        except KeyError as exc:
+            missing_attr = exc.args[0]
+            be_name = self.__class__.__name__
+            raise PermissionError(f"SAML2 backend {be_name} missing attribute: {missing_attr}")
+
+        if "FLAGS_BY_GROUP" in be_settings and "GROUP_ATTR" in be_settings:
+            for flag, group_name in be_settings["FLAGS_BY_GROUP"].items():
+                if group_name in ident_groups:
+                    setattr(user, flag, True)
+                else:
+                    setattr(user, flag, False)
+        if "GROUP_MAPPINGS" in be_settings and "GROUP_ATTR" in be_settings:
+            user_groups = []
+            for saml_group, django_group in be_settings["GROUP_MAPPINGS"].items():
+                if saml_group in ident_groups:
+                    user_groups.append(Group.objects.get(name=django_group))
+            user.groups.set(user_groups)
+        user.save()
 
         # call Netbox superclass for further processing of REMOTE_AUTH_xxx variables.
         return super().configure_user(request, user)


### PR DESCRIPTION
This PR adds the `SAML2CustomAttrUserBackend` which configures a user from customizable SAML attributes.
The backend reads its configuration from the `CUSTOM_ATTR_BACKEND` dict in the plugin config.