### PR TITLE
Add SSO login button instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,15 @@ are two notes in this process:
    1.  You MAY need to disable port in redirect depending on your Netbox installation.  If your Netbox server URL
    does _not_ include a port, then you _must_ disable port redirect.  For example see [nginx.conf](nginx.conf#L19).
    1.  You MUST add the ULR rewrite for the `/login/` URL to use `/plugins/sso/login/`, for example [nginx.conf](nginx.conf#L35).
+
+# Adding a SSO Login Button
+
+Instead of using a reverse proxy redirect, you can add a SSO login button above
+the NetBox login form. This has the added benefit of allowing both local
+and SAML login simultaneously.
+
+Add the following to your configuration.py:
+```python
+BANNER_LOGIN = '<a href="/api/plugins/sso/login" class="btn btn-primary btn-block">Login with SSO</a>'
+```
+

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ are two notes in this process:
 
 Instead of using a reverse proxy redirect, you can add a SSO login button above
 the NetBox login form. This has the added benefit of allowing both local
-and SAML login simultaneously.
+and SAML login options.
 
 Add the following to your configuration.py:
 ```python


### PR DESCRIPTION
This PR adds instructions to the readme to add a SSO login button above the NetBox login form.
It can be used as an alternative to the reverse proxy redirect method.

![image](https://user-images.githubusercontent.com/24482041/110224091-82825480-7e8d-11eb-90f9-da4a9a547ccb.png)
