### PR TITLE
Add v3.0 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ such as Okta.
 *NOTE: This approach uses a reverse-proxy URL rewrite so that the standard Netbox Login will redirect
 the User to the SSO system.  Please refer to the example [nginx.conf](nginx.conf) file.*
 
-*NOTE: Netbox plugin for SSO, v2.0+, supports Netbox 2.8, 2.9, 2.10, 2.11.
+*NOTE: Netbox plugin for SSO, v2.0+, supports Netbox 2.8, 2.9, 2.10, 2.11, 3.0.
 
 ## System Requirements
 
@@ -26,6 +26,10 @@ In the `configuration.py` you will need to enable and configure these
 ```python
 REMOTE_AUTH_ENABLED = True
 REMOTE_AUTH_BACKEND = 'utilities.auth_backends.RemoteUserBackend'
+# For v2.8+:
+# REMOTE_AUTH_BACKEND = 'netbox.authentication.RemoteUserBackend'
+# For backends included with this plugin:
+# REMOTE_AUTH_BACKEND = 'django3_saml2_nbplugin.backends.<Backend>'
 REMOTE_AUTH_AUTO_CREATE_USER = True
 ````
 


### PR DESCRIPTION
I've tested v3.0 with the `SAML2CustomAttrUserBackend` and everything seems to be working.
I've updated the README to include 3.0 and have clarified `REMOTE_AUTH_BACKEND` since it seems to be 
a common configuration error.

One thing to note is that a version of pysaml2 that includes IdentityPython/pysaml2@1b9723753fae3fc535b0e18e236d2d87f3cc2353 must be used for Python 3.9+ support. Perhaps you could push another version of django3-auth-saml2 with updated requirements to pypi? I've tested the plugin with pysaml2 v6.5.2 and everything seems to work fine.