### PR TITLE
Update for NetBox 4.0 syntax

### DIFF
--- a/django3_saml2_nbplugin/__init__.py
+++ b/django3_saml2_nbplugin/__init__.py
@@ -8,7 +8,7 @@ Do not try to modify django.conf.settings.SAML2_AUTH_CONFIG since by the time
 this plugin is invoked the settings is already configured, and if you try
 settings.configure(SAML2_AUTH_CONFIG=user_config) an exception will be raised.
 """
-from extras.plugins import PluginConfig
+from netbox.plugins import PluginConfig
 from django3_auth_saml2.config import SAML2_AUTH_CONFIG
 
 


### PR DESCRIPTION
@jeremyschulman for your review.  This PR updates the class name for a breaking change required for it to work in NetBox 4.0.  It will make the plugin no longer backward compatible with previous versions of NetBox.