### PR TITLE
update imports to support Netbox v4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ the User to the SSO system.  Please refer to the example [nginx.conf](nginx.conf
 
 *NOTE: Netbox plugin for SSO, v2.0+, supports Netbox 2.8, 2.9, 2.10, 2.11, 3.0.
 
+*NOTE: Netbox plugin for SSO, v3.0+, supports Netbox 4.0.
+
 ## System Requirements
 
 You will need to install the [django3-auth-saml2](https://github.com/jeremyschulman/django3-auth-saml2)
@@ -140,4 +142,3 @@ Add the following to your configuration.py:
 ```python
 BANNER_LOGIN = '<a href="/api/plugins/sso/login" class="btn btn-primary btn-block">Login with SSO</a>'
 ```
-

--- a/django3_saml2_nbplugin/__init__.py
+++ b/django3_saml2_nbplugin/__init__.py
@@ -8,7 +8,7 @@ Do not try to modify django.conf.settings.SAML2_AUTH_CONFIG since by the time
 this plugin is invoked the settings is already configured, and if you try
 settings.configure(SAML2_AUTH_CONFIG=user_config) an exception will be raised.
 """
-from extras.plugins import PluginConfig
+from netbox.plugins import PluginConfig
 from django3_auth_saml2.config import SAML2_AUTH_CONFIG
 
 

--- a/django3_saml2_nbplugin/backends.py
+++ b/django3_saml2_nbplugin/backends.py
@@ -1,7 +1,8 @@
 from typing import Optional
-from django.contrib.auth.models import User, Group
-from django.core.handlers.wsgi import WSGIRequest
 from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.handlers.wsgi import WSGIRequest
+from netbox.authentication import Group
 from saml2.response import AuthnResponse
 
 # Subclass from the Netbox provided RemoteUserBackend so that we get the


### PR DESCRIPTION
@jeremyschulman
According to the netbox docs `extras.plugins` was renamed to `netbox.plugins`. Furthermore netbox no longer uses `django.contib.auth.models` to handle groups but `netbox.authentication`. 
These changes will make the plugin incompatible with netbox versions before v4.0.

I took the liberty and already updated the Readme to say that the new release that includes this PR has the major version 3.