### PR TITLE
Change "FLAGS_BY_GROUP" in backends.py to accept array of groups

### DIFF
--- a/django3_saml2_nbplugin/backends.py
+++ b/django3_saml2_nbplugin/backends.py
@@ -171,8 +171,10 @@ class SAML2CustomAttrUserBackend(RemoteUserBackend):
             pass
 
         if "FLAGS_BY_GROUP" in be_settings and "GROUP_ATTR" in be_settings:
-            for flag, group_name in be_settings["FLAGS_BY_GROUP"].items():
-                if group_name in ident_groups:
+            for flag, group_names in be_settings["FLAGS_BY_GROUP"].items():
+                if not isinstance(group_names, list):
+                    group_names = [group_names]
+                if any(group_name in ident_groups for group_name in group_names):
                     setattr(user, flag, True)
                 else:
                     setattr(user, flag, False)


### PR DESCRIPTION
This commit changes the logic of the "FLAGS_BY_GROUP" parameter such that it can accept an array of group names. This will allow multiple groups to be configured with the respective flag.

I'm not a Django or Netbox expert, and I'd consider myself more of a beginner for both. Please double check this work and verify if this makes sense on the grander scheme to implement. I wanted to set one SAML group so it only got "is_staff", and I wanted to set another SAML group so it got both "is_staff" and "is_superuser", but found the plugin would accept the array without crashing, but would only manage the flag for the first group in the array. While looking through the issue tracker for related questions, I found #77 so I decided to take this on myself and create a pull request.