### PR TITLE
Bump version to 3.0 to align with Github release

### DIFF
--- a/django3_saml2_nbplugin/__init__.py
+++ b/django3_saml2_nbplugin/__init__.py
@@ -16,7 +16,7 @@ class Django3AuthSAML2Plugin(PluginConfig):
     name = 'django3_saml2_nbplugin'
     verbose_name = 'Netbox SSO SAML2 plugin'
     description = 'SSO support using SAML 2.0'
-    version = '2.0'
+    version = '3.0'
     author = 'Jeremy Schulman'
     base_url = 'sso'
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='netbox-plugin-auth-saml2',
-    version='2.3',
+    version='3.0',
     description='Netbox plugin for SAML2 auth',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
When using version 3.0 it's showing as 2.0 in NetBox
<img width="278" height="93" alt="image" src="https://github.com/user-attachments/assets/01fd6d4f-c1b1-492a-8014-15098bbb7637" />
